### PR TITLE
Add createHoppings and constructHamiltonians

### DIFF
--- a/src/hamiltonian/ConstructHamiltonian.jl
+++ b/src/hamiltonian/ConstructHamiltonian.jl
@@ -1,0 +1,39 @@
+using LinearAlgebra
+using SparseArrays
+using Arpack
+using Distributions
+
+# Takes in the parameter list and the vector potential
+function genH(p, H₀, edge_NNs)
+     NormalDist = Normal(0,p.μ_disorder)
+     H_onsite = Diagonal(rand(NormalDist,p.n*p.nsite))⊗I(p.norb*2) .+ p.μ*I(p.n*p.nsite*p.norb*2)
+     Hᵦ = 0I(p.n*p.nsite*p.norb*2)
+	ntot = p.n*p.nsite*p.norb*2
+	H₀ = sparse(H₀ .+ H_onsite .+ Hᵦ)
+	function H(k)
+		if(any(isnan,k)==true)
+               throw(DomainError(k, "Something broken in k vector definition! Returning NaN"))
+               return
+		end
+		# hamiltonian describing the edges
+          #build sparse as Hₑ = sparse(rows, cols, elements)
+          rows = Int[]; cols = Int[]; elements = ComplexF64[];
+          for NN in edge_NNs
+               Δϕ = exp(im*k⋅(p.A*NN.N))
+               for i = 1:2
+                    for j = 1:2
+                         push!(rows,2*NN.b+i-2);
+                         push!(cols,2*NN.a+j-2);
+                         push!(elements,copy(NN.t[i,j]*Δϕ))
+                    end
+               end
+		end
+		Hₑ = sparse(rows,cols,elements)
+		if(size(Hₑ) == (0,0)) Hₑ = spzeros(ComplexF64,ntot,ntot) end 
+		#println("Hedges = $(size(Hₑ)), H₀ = $(size(H₀))")
+		Htot = H₀ .+ Hₑ
+		return dropzeros(Htot)
+	end
+	println("Great, SCF converged. Returning H(k).\n")
+	return H 
+end

--- a/src/hamiltonian/Module.jl
+++ b/src/hamiltonian/Module.jl
@@ -1,0 +1,6 @@
+module HamiltonianModule
+
+include("ConstructHamiltonian.jl")
+export Hgen
+
+end

--- a/src/hoppings/Materials.jl
+++ b/src/hoppings/Materials.jl
@@ -1,0 +1,218 @@
+mutable struct Hopping
+	a::Int # orbital/site index 1
+	b::Int # orbital/site index 2 with PBC
+	ia # index vector of site A
+	ib # index vector of site B without PBC
+	ra # location of atom a
+	rb # location of atom b
+	r # radius from a to b
+	t  # hopping parameter affiliated with c†₂c₁ in spin basis. (i.e., t*I(2) or t*σ₊ might make sense)
+	edge::Bool # does this hop off the edge of the superlattice?
+	N # vector describing the [n₁;n₂;n₃]⋅[a₁;a₂;a₃] superlattice unit cell of site ib
+	desc::String
+end
+
+function metalHopping(p::NamedTuple,NNs::Vector{Hopping},ia::Vector{Int})
+	iorb = ia[5]
+	t = (3*p.t - 1*eV)*(I(2))
+	pushHopping!(NNs, t, ia, ia, p)
+	for ax = 1:3
+		for dir = [-1,1]
+			# for weyl term in hamiltonian
+			di = zeros(5); di[ax] = dir; ib = Int.(ia + di)
+			#Ra = xyztor(p,ia); Rb = xyztor(p,ib); 
+			#δ = Rb - Ra
+			# implement H = +vf*𝐩⋅𝛔 = -vf𝑖ħ ∇ᵣ⋅σ on finite grid
+            t = -1*p.t*I(2)
+			pushHopping!(NNs, t, ia, ib, p)
+                        #t = (p.ϵ₁ + 2*p.t)*(I(2))
+                        #pushHopping!(NNs, t, ia, ia, p)
+		end
+	end
+end
+
+function insHopping(p::NamedTuple,NNs::Vector{Hopping},ia::Vector{Int})
+	iorb = ia[5]
+	t = (p.ε₁ + 3*p.t)*(I(2))
+	pushHopping!(NNs, t, ia, ia, p)
+	for ax = 1:3
+		for dir = [-1,1]
+			# for weyl term in hamiltonian
+			di = zeros(5); di[ax] = dir; ib = Int.(ia + di)
+            t = -1/2*p.t*I(2)
+			pushHopping!(NNs, t, ia, ib, p)
+                        #t = (p.ϵ₁ + 2*p.t)*(I(2))
+                        #pushHopping!(NNs, t, ia, ia, p)
+		end
+	end
+end
+
+function nextsite(iorb::Int)
+    return (1-2*iorb)
+end
+
+
+function pushHopping!(NNs::Vector, t, ia::Vector{Int}, ib::Vector{Int}, p) 
+	a = xyztoi(p,ia); b = xyztoi(p,ib);
+	ra = xyztor(p,ia); rb = xyztor(p,ib); r = rb - ra;
+	# for hopping term
+	NN = deepcopy(Hopping(a,b,ia,ib,ra,rb,r,t, false, [0;0;0],""))
+	push!(NNs,NN)
+end
+
+function weyl3Hopping(p::NamedTuple,NNs::Vector{Hopping},ia::Vector{Int})
+        iorb = ia[5]
+        ib = ia; 
+	# nearest neighbors
+        for ax = 1:3
+		for dir = [-1,1]
+			# for weyl term in hamiltonian
+			di = zeros(5); di[ax] = dir; 
+                        #di[5] = nextsite(iorb); 
+                        ib = Int.(ia + di)
+                        t = zeros(ComplexF64,2,2)
+                        if(ax == 3)
+                            t = p.t*σ[3]
+                        elseif(ax==1)
+                            t == p.t*(-σ[3] .+ dir*2*im*σ[1])
+                        elseif(ax==2)
+                            t == p.t*(-σ[3] .+ dir*2*im*σ[2])
+                        else
+                            println("Something broken! No 4th axis")
+                        end
+			pushHopping!(NNs, t, ia, ib, p)
+		end
+	end
+        # next nearest neighbors
+        for dx = [-1,1]
+            for dy = [-1,1]
+                di = zeros(5); di[1] = dx; di[2] = dy;
+                ib = Int.(ia+di)
+                t = 1.5*im*p.t*(-dx*σ[1] .+ -dy*σ[2]) # implements the next-nearest neigbor term
+                pushHopping!(NNs, t, ia, ib, p)
+            end
+        end
+        # next-to-next nearest neighbors
+        for ax = 1:2
+            for dir = [-1,1]
+                di = zeros(5); di[ax] = 2*dir
+                ib = Int.(ia+di)
+                t = dir*p.t*0.5*im*σ[ax]
+                pushHopping!(NNs, t, ia, ib, p)
+            end
+        end
+end
+
+
+function weyl2Hopping(p::NamedTuple,NNs::Vector{Hopping},ia::Vector{Int})
+        iorb = ia[5]
+        ib = ia; 
+	# nearest neighbors
+        for ax = 1:3
+		for dir = [-1,1]
+			# for weyl term in hamiltonian
+			di = zeros(5); di[ax] = dir; 
+                        #di[5] = nextsite(iorb); 
+                        ib = Int.(ia + di)
+                        t = zeros(ComplexF64,2,2)
+                        if(ax == 1)
+                            t = p.t*(σ[1].-σ[3])
+                        elseif(ax==2)
+                            t = -p.t*(σ[1].+σ[3])
+                        elseif(ax==3)
+                            t = p.t*σ[3]
+                        else
+                            println("Something broken! No 4th axis")
+                        end
+                        #t = (-im/2)*dir*p.t*σ[ax]
+			pushHopping!(NNs, t, ia, ib, p)
+		end
+	end
+        for dx = [-1,1]
+            for dy = [-1,1]
+                di = zeros(5); di[1] = dx; di[2] = dy;
+                ib = Int.(ia+di)
+                t = -dx*dy*0.5*p.t*σ[2] # implements the next-nearest neigbor term
+                pushHopping!(NNs, t, ia, ib, p)
+            end
+        end
+end
+
+function chern2DHopping(p::NamedTuple,NNs::Vector{Hopping},ia::Vector{Int})
+        iorb = ia[5]
+        ib = ia; 
+        #ib[5] += nextsite(iorb)
+        #t = 3*p.t*(I(2))
+	#pushHopping!(NNs, t, ia, ib , p)
+        # for H₂ = τ₃⊗σ₀
+        t = nextsite(iorb)*(2*p.m2+p.γ)*(I(2))
+	pushHopping!(NNs, t, ia, ia, p)
+	for ax = 1:3
+		for dir = [-1,1]
+			# for weyl term in hamiltonian
+			di = zeros(5); di[ax] = dir; 
+                        # for Hweyl = τ₁⊗k⋅σ
+                        di[5] = nextsite(iorb); 
+                        ib = Int.(ia + di)
+                        t = (im/2)*dir*p.t*σ[ax]
+			#Ra = xyztor(p,ia); Rb = xyztor(p,ib); 
+			#δ = Rb - Ra
+			# implement H = +vf*𝐩⋅𝛔 = -vf𝑖ħ ∇ᵣ⋅σ on finite grid
+                        #t = nextsite(iorb)*(-im/2)*dir*p.t*σ[ax]
+			pushHopping!(NNs, t, ia, ib, p)
+			# for normal hopping term in hamiltonian
+			ib[5] = iorb; 
+			
+			t = -(1/2)*nextsite(iorb)*p.m2*(I(2))
+			pushHopping!(NNs, t, ia, ib, p)
+		end
+	end
+end
+
+
+function weylHopping(p::NamedTuple,NNs::Vector{Hopping},ia::Vector{Int})
+        iorb = ia[5]
+        ib = ia; 
+        #ib[5] += nextsite(iorb)
+        #t = 3*p.t*(I(2))
+	#pushHopping!(NNs, t, ia, ib , p)
+        # for H₂ = τ₃⊗σ₀
+        t = 3*nextsite(iorb)*p.t*(I(2))
+	pushHopping!(NNs, t, ia, ia, p)
+	for ax = 1:3
+		for dir = [-1,1]
+			# for weyl term in hamiltonian
+			di = zeros(5); di[ax] = dir; 
+                        # for Hweyl = τ₁⊗k⋅σ
+                        di[5] = nextsite(iorb); 
+                        ib = Int.(ia + di)
+                        t = (-im/2)*dir*p.t*σ[ax]
+			#Ra = xyztor(p,ia); Rb = xyztor(p,ib); 
+			#δ = Rb - Ra
+			# implement H = +vf*𝐩⋅𝛔 = -vf𝑖ħ ∇ᵣ⋅σ on finite grid
+                        #t = nextsite(iorb)*(-im/2)*dir*p.t*σ[ax]
+			pushHopping!(NNs, t, ia, ib, p)
+			# for normal hopping term in hamiltonian
+			ib[5] = iorb; 
+			
+			t = -(1/2)*nextsite(iorb)*p.t*(I(2))
+			pushHopping!(NNs, t, ia, ib, p)
+		end
+	end
+end
+
+
+hoppingDict = Dict{String,Function}(
+                                    "mtjweyl"=>weylHopping,
+                                    "2Dchern"=>chern2DHopping,
+                                    "weyl"=>weylHopping,
+                                    "weyl2"=>weyl2Hopping,
+                                    "weyl3"=>weyl3Hopping,
+                                    "wins"=>insHopping,
+                                    "ins"=>insHopping,
+                                    "insulator"=>insHopping,
+                                    "metal"=>metalHopping
+                                   )
+
+
+#end

--- a/src/hoppings/Module.jl
+++ b/src/hoppings/Module.jl
@@ -1,0 +1,6 @@
+module HoppingsModule
+
+include("createHoppings.jl")
+export genNNs, nnHoppingMat, pruneHoppings
+
+end

--- a/src/hoppings/createHoppings.jl
+++ b/src/hoppings/createHoppings.jl
@@ -1,0 +1,95 @@
+using LinearAlgebra
+include("Materials.jl")
+
+# Takes in the parameters p, index vector (ix,iy,iz,isite (in unit cell), and iorb)
+# returns the site-index in the full hamiltonian
+function xyztoi(p,ivec, N::Vector{Int} = [0;0;0]) 
+	# indexing 0 to N-1
+	# in case the A₂ lattice vector != C*[0;1;0]
+	diy = Int(round(p.SLa₂[1]/p.a₁[1]))*N[2]
+	ix = mod(ivec[1],p.nx); iy = mod(ivec[2] + diy,p.ny); iz = mod(ivec[3],p.nz); isite = ivec[4]; iorb = ivec[5]
+	return iorb + p.norb*isite + p.nsite*p.norb*ix + p.nsite*p.norb*p.nx*iy + p.nsite*p.norb*p.nx*p.ny*iz + 1
+end
+
+# Same as above, except returns the corresponding atomic position of each index vector 
+# useful for calculating ∫A⋅δR peierls phase
+function xyztor(p,ivec)
+	ix = ivec[1]; iy = ivec[2]; iz = ivec[3]; isite = ivec[4];
+	δdict = Dict(0 => p.A*[0.0; 0.0; 0.0], #In 1 
+		     1 => p.A*[0.5; 0.5; 0.5]) #In 2
+		     #2 => p.A*[0.0; 0.5; 0.8975-0.5], #Bi 1
+		     #3 => p.A*[0.5; 0.0; 1.10248-0.5]) #Bi 2
+	δ = δdict[isite]    
+	R = p.a₁*ix + p.a₂*iy + p.a₃*iz + δ
+	return R
+end
+
+# Generate H₀ and make a list of edge bonds for generating H(k)
+function nnHoppingMat(NNs,p)
+	N = p.n*p.nsite*p.norb
+	H = zeros(ComplexF64,2*N,2*N)
+	edgeNNs = Any[]
+	for NN in NNs
+		if(NN.edge == true)
+			push!(edgeNNs,deepcopy(NN))
+		else
+			# at site 1->2 would be a_2,1
+			# with site ⊗ spin, would be 
+			H[2*NN.b-1, 2*NN.a-1] += NN.t[1,1]
+			H[2*NN.b  , 2*NN.a-1] += NN.t[2,1]
+			H[2*NN.b-1, 2*NN.a  ] += NN.t[1,2]
+			H[2*NN.b  , 2*NN.a  ] += NN.t[2,2]
+		end
+	end
+	return H, edgeNNs
+end
+
+rot(θ) = [cos(θ) -sin(θ); sin(θ) cos(θ)]
+
+
+function genNNs(p) # all of the terms in the hamiltonian get added here, get back the relevant bonds
+	NNs = Hopping[]
+	function nextsite(isite::Int)
+		return -2*isite + 1
+	end
+	# loop over each unit cell site in the superlattice
+	for iy = 0:(p.ny-1)
+		for iz = 0:(p.nz-1)
+			for ix = 0:(p.nx-1)
+				isite = 0
+				for iorb = 0:(p.norb-1)
+					ia = copy([ix,iy,iz,isite,iorb]);
+					hoppingType! = hoppingDict[p.deviceMaterial]
+					hoppingType!(p,NNs,ia)
+				end
+			end
+		end
+	end
+	# now fix the designation for the vectors that hop out of the lattice
+	# Will connect them around later using bloch's theorem to generate H(k) function
+	for NN in NNs
+		ib = [NN.ib[1],NN.ib[2],NN.ib[3]]
+		# Δ(ib,ib reflected back into 1st lattice)
+		pib = ib - [mod(ib[1],p.nx),mod(ib[2],p.ny),mod(ib[3],p.nz)]
+		if(pib⋅pib != 0) # if vector is distinctly outside of 1st lattice
+			NN.N = Int.([round(pib[1]/(p.nx)),round(pib[2]/p.ny),round(pib[3]/p.nz)])
+			NN.b = xyztoi(p,NN.ib, NN.N)
+			NN.edge = true
+		end
+	end
+	return NNs
+end
+
+
+function pruneHoppings(NNs, type)
+	if("x" ∈ type)
+		deleteat!(NNs, findall(NN->NN.N[1]!=0,NNs))
+	end
+	if("y" ∈ type)
+		deleteat!(NNs, findall(NN->NN.N[2]!=0,NNs))
+	end
+	if("z" ∈ type)
+		deleteat!(NNs, findall(NN->NN.N[3]!=0,NNs))
+	end
+	return NNs
+end

--- a/test/InBi.jl
+++ b/test/InBi.jl
@@ -1,0 +1,162 @@
+module InBi
+export params, kdictGen, genSL
+
+# constants
+
+ħ = 1 #hbar
+h = ħ * 2*π
+m₀ = 1 #electron mass
+q = 1 #electron charge
+ϵ₀ = 1 #permittivity
+r₀ = 1 #bohr radii
+Ry = 1/2 #rydberg
+au = 1 #hartree energy
+Å = 1.8897 * r₀	#angstrom, in hartree units
+nm = 10 * Å 		#angstrom, in hartree units
+qHo = 67;
+eV = au/27.2
+ε = 0.0*eV; ε₂ = 0.0*eV #onsite energy for In, Bi
+
+# electronic properties
+t = 1*eV
+t₁ = 1*eV; # In-Bi px-px,py-py
+t₂ = 1*eV; # In-In 1st NN hopping
+t₃ = 1*eV; #Bi-Bi 1st NN hopping
+t₄ = 0 # obsolete
+t₅ = 0.17*eV # In-In 2nd NN hopping
+t₆ = 0.04*eV;# Bi-Bi 2nd NN hopping
+t₇ = 0.0*eV;# In-Bi further hoppings
+t₈ = -0.1*eV;# In-In 2nd nn vertical hoppings
+t₉ = 0.0*eV;# In-In px -px, py-py hoppings
+ε₁ = 1.9*eV; ε₂ = -1.2*eV #onsite energy for In, Bi
+
+# structural properties
+#a = 4.8*Å; c = 4.8*Å
+a = 1; c = 1
+A = [a 0 0; 0 a 0; 0 0 c]
+a₁ = A[:,1]; a₂ = A[:,2]; a₃ = A[:,3]
+B = transpose(2*π*inv(A))
+b₁ = B[:,1]; b₂ = B[:,2]; b₃ = B[:,3]
+
+nx = ny = nz = 1; n = nx*ny*nz
+
+
+function kdictGen(A)
+	B = transpose(2*π*inv(A))
+	kdict = Dict(
+		"Γ" => B*[ 0  ;    0;   0],
+		"Γ + iX₁" => B*[ im/2  ;    0;   0],
+		"Γ + 10*iX₁" => B*[ 10*im/2  ;    0;   0],
+		"A" => B*[ 1/2;  1/2; 1/2],
+		"M" => B*[ 1/2;  1/2;   0],
+		"Z" => B*[   0;    0; 1/2],
+		"-Z" => B*[  0;    0;-1/2],
+		"X₁" => B*[   1/2;    0; 0],
+		"-X₁" => B*[  -1/2;    0;0],
+		"X₂" => B*[   0;    1/2; 0],
+		"-X₂" => B*[  0;  -1/2;0],
+		"X₃" => B*[   0;    0; 1/2],
+		"-X₃" => B*[  0;    0;-1/2],
+		
+				"-X₃" => B*[  0;    0;-1/2],
+		"-X₃" => B*[  0;    0;-1/2],
+		"-X₃" => B*[  0;    0;-1/2],
+		"-X₃" => B*[  0;    0;-1/2],
+		)
+	return kdict
+end
+
+
+params = (
+	  t = t, t₁ = t₁, t₂ = t₂, t₃ = t₃, t₄ = t₄, t₅ = t₅, t₆ = t₆, t₇ = t₇, t₈ = t₈, t₉ = t₉,
+	  vf = 10^6, η = 10^-3,
+	  ε = ε, ε₁ = 2*eV, 
+	  a₁ = a₁, a₂ = a₂, a₃ = a₃, A = A, a=a, b=a, c=c,
+	  SLa₁ = a₁, SLa₂ = a₂, SLa₃ = a₃,
+	  nx = nx, ny = ny, nz = nz, n = n, norb = 1, nsite = 1,
+	  kdict = kdictGen(A), prune = [], μ_disorder = 0.025*eV
+	  )
+
+function pruneHoppingType(runtype::String="")
+	println("runtype = $runtype")
+	if(runtype ∈ ["nanopillars", "eggcarton", "afmthinfilm", "fmthinfilm", "fmdotsP", "fmdotsAP", "neelwall", "blochwall" ])
+		return []
+		#return ["z"]
+	end
+	if(runtype == "domainwallthin")
+		return ["z","y"]
+	end
+	if(runtype == "device")
+		return ["x","y","z"]
+	end
+	return []
+end
+
+
+function genLatSL(p,SL1::Vector{Int},SL2::Vector{Int},SL3::Vector{Int})
+	SLa₁ = SL1[1]*p.a₁ + SL1[2]*p.a₂ + SL1[3]*p.a₃
+	SLa₂ = SL2[1]*p.a₁ + SL2[2]*p.a₂ + SL2[3]*p.a₃
+	SLa₃ = SL3[1]*p.a₁ + SL3[2]*p.a₂ + SL3[3]*p.a₃
+	return SLa₁, SLa₂, SLa₃
+end
+
+function genSL(p,nx::Int,ny::Int,nz::Int,SL1::Vector{Int},SL2::Vector{Int},SL3::Vector{Int},runtype::String="",fieldtype="A")
+	SLa₁, SLa₂, SLa₃ = genLatSL(p,SL1,SL2,SL3)
+	newA = hcat(nx*p.SLa₁,ny*p.SLa₂,nz*p.SLa₃)
+	if(nx*ny*nz*p.norb*p.nsite > 64)
+		arpack = true
+	else
+		arpack = false
+	end
+        pruning = String[]
+        if(p.prune == [])
+            pruning = pruneHoppingType(runtype)
+        else
+            pruning = p.prune
+        end
+        SLparams = (
+		SLa₁ = newA[:,1], SLa₂ = newA[:,2], SLa₃ = newA[:,3],
+		A = newA, B = 2*π*transpose(inv(newA)),
+		nx = nx, ny = ny, nz = nz, n=nx*ny*nz,
+		kdict = kdictGen(newA),
+		runtype=runtype,
+		arpack=arpack,
+		prune=pruning,
+		klist = ["M","Γ","X₁","M","X₂","Γ", "X₃"],
+		fieldtype=fieldtype
+	)
+	return merge(p,SLparams)
+end
+
+function generateParams()
+	⊗(A,B) = kron(A,B)
+	nx = 1; ny = 1; nz = 1;
+    SL1 = [nx; 0; 0]; SL2 = [0; ny; 0]; SL3 = [0; 0; nz]
+
+    runparams = (
+        # fermi energy, σ of background disorder
+        μ = 0.0*eV, μ_disorder = 0.0*eV, 
+
+        # exchange splitting, name of field pattern, A or β (vector pot or exchange), finite-time broadenings
+        runtype = "blochlattice", fieldtype = "β",
+
+        # things to return 
+        returnvals = ["transmission"],
+        prune=[]
+    )
+
+    parms = merge(params,runparams)
+    p = InBi.genSL(parms, nx, ny, nz, SL1, SL2, SL3, parms.runtype, parms.fieldtype) # generate SL params
+    # supercell consisting of one unit cell
+    pNNs = (n = p.n, nx = p.nx, ny = p.ny, nz = p.nz, nsite = p.nsite, norb = p.norb,
+            t = 1, SLa₂ = p.SLa₂, a₁ = p.a₁, a₂ = p.a₂, a₃ = p.a₃, deviceMaterial = "ins", 
+            ε₁ = p.ε₁, A = p.A, fieldtype = "A")
+	pH = (μ = p.μ, μ_disorder = p.μ_disorder, n = p.n, norb = p.norb, nsite = p.nsite, 
+			A = p.A, t = p.t, ε₁ = p.ε₁)
+	pHopMat = (n = p.n, nsite = p.nsite, norb = p.norb, t = p.t, ε₁ = p.ε₁)
+    return pNNs, pH, pHopMat
+end
+
+end
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,12 @@ All other dependencies for tests besides the QuantumTransport package and the Te
         include("self-energies.jl")
     end
 
+    println("------------RUNNING HOPPING HAMILTONIAN TESTS------------")
+    @testset "Hopping Hamiltonian Test" begin
+        include("testHoppings.jl")
+
+    end
+
     # cannot fully test Data Visualization because GitHub does not have a GPU
     # non interactive image plots generated, however we want to generate interactive plots
     @testset "Data Visualization Test" begin

--- a/test/testHoppings.jl
+++ b/test/testHoppings.jl
@@ -1,0 +1,49 @@
+using QuantumTransport
+
+include("InBi.jl")
+include("../src/hoppings/createHoppings.jl")
+include("../src/hoppings/Materials.jl")
+include("../src/hamiltonian/ConstructHamiltonian.jl")
+
+function genNN(pNNs) 
+    NNs = genNNs(pNNs)
+
+    @assert length(NNs) == 7
+    @assert NNs[2].N[1] == -1 && NNs[2].edge == true #-x
+    @assert NNs[3].N[1] == 1 && NNs[3].edge == true #+x
+    @assert NNs[4].N[2] == -1 && NNs[4].edge == true #-y
+    @assert NNs[5].N[2] == 1 && NNs[5].edge == true #+y
+    @assert NNs[6].N[3] == -1 && NNs[6].edge == true #-z
+    @assert NNs[7].N[3] == 1 && NNs[7].edge == true #+z
+    return NNs
+end
+
+function checkNNs(NNs, pNNs) 
+    newNNs = genNNs(pNNs)
+    @testset verbose = true "Hopping Parameters[$i]" for i in range(1,7)
+        @test newNNs[i].a == NNs[i].a 
+        @test newNNs[i].b == NNs[i].b
+        @test newNNs[i].ia == NNs[i].ia 
+        @test newNNs[i].ib == NNs[i].ib
+        @test newNNs[i].ra == NNs[i].ra 
+        @test newNNs[i].rb == NNs[i].rb
+        @test newNNs[i].t == NNs[i].t
+        @test newNNs[i].edge == NNs[i].edge
+        @test newNNs[i].N == NNs[i].N
+    end
+end
+
+function testHGen(p, H₀, edge_NNs)
+    H = genH(p, H₀, edge_NNs)
+    sparseArray = H([0;0;0])
+    #up-spin, down-spin
+    @assert sparseArray.m == 2 && sparseArray.n == 2
+end
+
+⊗(A,B) = kron(A,B)
+pNNs, pH, pHopMat = InBi.generateParams()
+NNs = genNN(pNNs)
+checkNNs(NNs, pNNs)
+NNs = pruneHoppings(NNs, []) #p needs a prune value
+H₀, edge_NNs = nnHoppingMat(NNs, pHopMat)
+H = testHGen(pH, H₀, edge_NNs)


### PR DESCRIPTION
This commit includes the source code for creating the Hoppings graph and creating the Hamiltonian graph. The Hoppings requires a helper file named Materials that determines how electrons move depending on the material. Construct Hamiltonian builds on the inputed values generated by createHoppings to create the Hamiltonian.

The source code is paired with tests that test the functionality. We have passed in a supercell that represents one unit cell and check to see if all directions are present when we create the Hoppings Graph. For the Hamiltonian, it outputs a 2x2 sparse graph because there's spin included in the creation of it (up and down spin).

This code is simply a basic functionality of creating the hamiltonian; I'll still need to add device magnetization, injecting parameters, hamiltonian modifications, and maybe even alterations based on vector potential. Therefore, this pull request is still a WIP, and I'll have more commits to add on top of this one.